### PR TITLE
Adding build capabilities for MacOS/ARM/M1-2020

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build-plugins*
 project_file.xml
 .qtc_clangd
 build/
+.DS_Store

--- a/src/iland/iland.pro
+++ b/src/iland/iland.pro
@@ -97,6 +97,8 @@ linux-g++ {
 # basically sudo apt-get install libfreeimage3 libfreeimage-dev
 
 LIBS += -lfreeimage
+}macx{ 
+LIBS += -L/opt/homebrew/Cellar/freeimage/3.18.0/lib -lfreeimage
 } else {
 # external freeimage library (geotiff)
 LIBS += -L$$THIRDPARTY_PATH\FreeImage -lFreeImage


### PR DESCRIPTION
### Adding build case for Mac by downloading and specifying the library in iland.pro.

`brew install freeimage`

Then, specifically for the M1 processor add:

`macx{-L/opt/homebrew/Cellar/freeimage/3.18.0/lib -lfreeimage}`

Other architectures may differ in the directory where freeimage is installed